### PR TITLE
HTMLに埋め込むリソースURIからスキーム部分を削る

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -29,7 +29,7 @@
     <% include includes() %>
 
     <!--[if lt IE 9]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script>
@@ -61,7 +61,7 @@
 <link rel="stylesheet" href="<% url "static" %>/codemirror/lib/codemirror.css">
 <link rel="stylesheet" href="<% url "static" %>/css/root.css">
 
-<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
+<script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 <script src="//platform.twitter.com/widgets.js"></script>
 <script src="<% url "static" %>/js/jquery.url.js"></script>


### PR DESCRIPTION
jQuery(とHTML5救済のJavaScript)がhttp://指定で埋め込まれるため、HTTPSサイトで運営しようとするとリソースが読み込まれないか「安全でないリソース」と表示される現象を回避します。