### PR TITLE
クッキーのパスがハードコーディングされている問題を修正

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -36,7 +36,7 @@
       document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/,'js');
     </script>
   </head>
-  <body>
+  <body data-webroot="<% url "root" %>">
     <noscript>
       <h1><a href="<% url "nojs-list" %>">Click this for noscript browsers</a></h1>
     </noscript>

--- a/kennel2/static/js/root.js
+++ b/kennel2/static/js/root.js
@@ -35,7 +35,7 @@ function update_compile_command(compiler) {
 }
 
 function save(key, value) {
-  $.cookie(key, value, { expires: 365, path: '/wandbox' });
+  $.cookie(key, value, { expires: 365, path: $('body').attr('data-webroot') });
 }
 
 $(function() {


### PR DESCRIPTION
https://github.com/melpon/wandbox/issues/141 の「`<body>` に `data-` 属性」パターン