### PR TITLE
標準出力や標準エラー出力へのANSIエスケープコード付きの出力に対応

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/jquery-cookie"]
 	path = submodules/jquery-cookie
 	url = https://github.com/carhartl/jquery-cookie.git
+[submodule "submodules/ansi_up"]
+	path = submodules/ansi_up
+	url = https://github.com/drudru/ansi_up.git

--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -67,6 +67,7 @@
 <script src="//platform.twitter.com/widgets.js"></script>
 <script src="<% url "static" %>/js/jquery.url.js"></script>
 <script src="<% url "static" %>/js/jquery.cookie.js"></script>
+<script src="<% url "static" %>/js/ansi_up.js"></script>
 <script src="<% url "static" %>/codemirror/lib/codemirror.js"></script>
 <script src="<% url "static" %>/codemirror/mode/clike/clike.js"></script>
 <script src="<% url "static" %>/codemirror/mode/d/d.js"></script>

--- a/kennel2/static/js/ansi_up.js
+++ b/kennel2/static/js/ansi_up.js
@@ -1,0 +1,1 @@
+../../../submodules/ansi_up/ansi_up.js

--- a/kennel2/static/js/root.js
+++ b/kennel2/static/js/root.js
@@ -984,7 +984,7 @@ ResultWindow.prototype.post_code = function(compiler, code, codes, stdin) {
     src.close();
 
     var outputs = self._output_window().find('pre').map(function(n,e) {
-        return { 'type': $(e).attr('data-type'), 'output': $(e).text() };
+        return { 'type': $(e).attr('data-type'), 'output': $(e).attr('data-text') };
     });
     self.permlink(compiler_info, code, codes, stdin, outputs);
 
@@ -1003,18 +1003,22 @@ ResultWindow.prototype.post_code = function(compiler, code, codes, stdin) {
              data.type == "StdOut" ||
              data.type == "StdErr";
     };
-    if (is_message(data.type) &&
-        preview_paragraph &&
-        preview_paragraph.hasClass(data.type)) {
-      var p = preview_paragraph;
-      p.text(p.text() + data.message)
-    } else {
-      var p = $('<pre>').addClass(data.type)
-                        .attr('data-type', data.type)
-                        .text(data.message)
-                        .appendTo(output);
-      preview_paragraph = p;
-    }
+    var p =
+        (is_message(data.type) &&
+         preview_paragraph &&
+         preview_paragraph.hasClass(data.type))
+            ? preview_paragraph
+            : $('<pre>').addClass(data.type).attr('data-type', data.type).attr('data-text', '').appendTo(output);
+    p.attr('data-text', p.attr('data-text') + data.message);
+    p.html(
+      ansi_up.ansi_to_html(
+        ansi_up.escape_for_html(
+          p.attr('data-text')
+        )
+      )
+    );
+    preview_paragraph = p;
+
     output[0].scrollTop = output[0].scrollHeight;
 
     if (data.type == 'Control' && data.message == 'Finish') {
@@ -1036,7 +1040,11 @@ ResultWindow.prototype.set_code = function(compiler, code, codes, stdin, outputs
     var output = e.output;
     $('<pre>').addClass(type)
               .attr('data-type', type)
-              .text(output)
+              .html(
+                ansi_up.ansi_to_html(
+                  ansi_up.escape_for_html(output)
+                )
+              )
               .appendTo(self._output_window());
   });
 }


### PR DESCRIPTION
https://github.com/melpon/wandbox/issues/127

* コンパイル時の出力は未確認

* 一定の条件で色が引き継がれない

    標準出力と標準エラー出力への出力がまざるような（たとえば交互に出力）プログラムで
    たまたま色が変わっているタイミングでぶった切られた時（この時、 `<pre>` タグが作り直される）

    対応するには、直前の同じ `type` の最後のカラー指定を覚えておくか、
    そもそも `<pre>` タグを作り直さないとかをしないといけない。

出力例: https://wandbox.fetus.jp/permlink/1HsrhDcxpp3gBk2k