### PR TITLE
IEに互換表示をさせない

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
 
     <title>[Wandbox]三へ( へ՞ਊ ՞)へ ﾊｯﾊｯ</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="description" content="Wandbox is Online Compiler">
     <meta name="author" content="melpon, kikairoya">
 


### PR DESCRIPTION
少なくともIE11で互換モードに落ちてひどいことになるので、互換モード使うなと指示することで改善します。

![ie11](https://cloud.githubusercontent.com/assets/848666/7785535/f8bf5dd8-01ce-11e5-8281-2f9bb305ca5e.png) ![ie11-2](https://cloud.githubusercontent.com/assets/848666/7785537/fd6358bc-01ce-11e5-8fc4-05ec9f9a3820.png)
