### PR TITLE
Vimモードにおける編集動作の改善

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -86,6 +86,7 @@
 <script src="<% url "static" %>/codemirror/mode/coffeescript/coffeescript.js"></script>
 <script src="<% url "static" %>/codemirror/keymap/vim.js"></script>
 <script src="<% url "static" %>/codemirror/keymap/emacs.js"></script>
+<script src="<% url "static" %>/codemirror/addon/search/searchcursor.js"></script>
 <script src="<% url "static" %>/js/PostEventSource.js"></script>
 
 <script>

--- a/kennel2/static/codemirror/addon
+++ b/kennel2/static/codemirror/addon
@@ -1,0 +1,1 @@
+../../../submodules/CodeMirror/addon


### PR DESCRIPTION
fetus-hina/wandbox@39a3693 :

* CodeMirror を最新リリース(NOT 最新コミット)である 5.6.0 に更新します

fetus-hina/wandbox@f8336ab

* CodeMirror の `searchcursor.js` を使用するようにします
    - Vimモードでしか試していませんが、`/hoge` といった検索や `:%s/hoge/fuga/g` のような置換が動作するようになります。Wandbox 規模でどの程度編集を行いたいかは謎ですが、`Error: Search feature not available. Requires searchcursor.js or any other getSearchCursor implementation.` と表示されるよりはマシかと。
    - refs #167