### PR TITLE
[Fix] 結果出力で "No Wrap" を外しても折り返されない問題を解消

### DIFF
--- a/kennel2/static/css/root.css
+++ b/kennel2/static/css/root.css
@@ -265,6 +265,7 @@ footer {
   color: #ffffff;
   border: 0px;
   font-family: "Courier New", monospace;
+  white-space: pre-wrap;
 }
 .output-window .CompilerMessageE {
   color: #ff0000;
@@ -287,7 +288,7 @@ footer {
 }
 
 .nowrap .output-window pre {
-  word-wrap: normal;
+  white-space: pre;
 }
 
 .wandbox-current-compiler-text {


### PR DESCRIPTION
これ、私の環境だけじゃないですよね…
![image](https://user-images.githubusercontent.com/2217224/44305761-13ba7a00-a3bb-11e8-9b85-94e65e011f71.png)

結果出力の "No Wrap" で CSS の word-wrap: normal が指定されていたが、
結果出力内はそもそも pre 要素なので改行文字か br 要素が無いと改行され
ない。

そこで、通常時は white-space: pre-wrap にして幅に応じて改行されるよう
にして、"No Wrap" 指定時には white-space: wrap に戻して改行されないよ
うにした。

