### PR TITLE
fix view height to good feels

### DIFF
--- a/kennel2/static/css/root.css
+++ b/kennel2/static/css/root.css
@@ -140,7 +140,6 @@ footer {
 
 .wandbox-smart-editor {
   margin: 0px;
-  min-height: 300px;
 }
 .wandbox-smart-editor .CodeMirror pre {
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', 'Courier New', monospace;
@@ -149,16 +148,10 @@ footer {
 }
 
 .wandbox-legacy-editor {
-  height: 300px;
   font-family: "Courier New", monospace;
 }
 
-.wandbox-smart-editor.wandbox-expand .CodeMirror {
-  min-height: 300px;
-  height: auto;
-}
 .wandbox-smart-editor.wandbox-expand .CodeMirror-scroll {
-  min-height: 300px;
   overflow-y: hidden;
   overflow-x: auto;
 }
@@ -252,10 +245,7 @@ footer {
 }
 .output-window {
   margin: 0px;
-
   background-color: #000000;
-  height: 300px;
-  overflow-y: scroll;
 }
 .output-window pre {
   margin: 0px 0px 10px;
@@ -280,11 +270,6 @@ footer {
 }
 .output-window .ExitCode {
   color: #ff00ff;
-}
-
-.expand .output-window {
-  min-height: 300px;
-  height: auto;
 }
 
 .nowrap .output-window pre {
@@ -520,4 +505,34 @@ footer {
 }
 .wandbox-datetime {
   display: inline;
+}
+
+/* remove nest scroll */
+.wandbox-smart-editor,
+.wandbox-legacy-editor,
+.wandbox-smart-editor .CodeMirror,
+.wandbox-smart-editor.wandbox-expand .CodeMirror,
+.wandbox-smart-editor.wandbox-expand .CodeMirror-scroll,
+.output-window,
+.expand .output-window {
+    min-height: 300px;
+    height: auto;
+}
+@media (min-width: 992px) {
+  .output-window {
+      overflow-y: scroll;
+  }
+}
+
+/* fit to view height */
+@media (min-width: 992px) {
+  .wandbox-smart-editor,
+  .wandbox-legacy-editor,
+  .wandbox-smart-editor .CodeMirror,
+  .wandbox-smart-editor.wandbox-expand .CodeMirror,
+  .wandbox-smart-editor.wandbox-expand .CodeMirror-scroll,
+  .output-window,
+  .expand .output-window {
+      height: calc(50vh - 15rem);
+  }
 }


### PR DESCRIPTION
PC向けの表示の時にはコードと出力の view を画面の高さに合わせて広げ、
スマフォ向けの表示の時にはコードと出力の view でスクロールバーが出ないようにコンテンツの高さに合わせて広げて全体を表示する修正になります。

細かい部分で気に入らないところがあったら適当に修正してください。( 特にいままでは出力のスクロールバーは常時表示だったのに、スマフォ向けの表示の時には表示されないようにしてるので )

```css
height: calc(50vh - 15rem);
```

ここの `15rem` は本当は画面上の他の要素の高さを調べ上げてその合計の半分になるようにするべきだとは思うんですが、メンテナンス上もかえって手間なだけになるだろうと思ったので適当に調整しただけのサイズです。今後、画面構成に変更があった際には適宜いい感じのサイズに調整してください。