### PR TITLE
Revert "Remove 'Expand' feature for editor/output window"

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -442,6 +442,11 @@ var LANGUAGE_NAME_TO_TAB_ID = {
         <input class="smart-indent" type="checkbox" value="smart-indent" checked>Smart Indent</input>
       </label>
     </div>
+    <div class="checkbox">
+      <label>
+        <input class="expand-editor" type="checkbox" value="expand-editor">Expand</input>
+      </label>
+    </div>
   </div>
 </div>
 <% end template %>
@@ -461,6 +466,11 @@ var LANGUAGE_NAME_TO_TAB_ID = {
       <div class="checkbox">
         <label>
           <input class="nowrap-output-window" type="checkbox" value="nowrap-output-window">No Wrap</input>
+        </label>
+      </div>
+      <div class="checkbox">
+        <label>
+          <input class="expand-output-window" type="checkbox" value="expand-output-window">Expand</input>
         </label>
       </div>
     </div>

--- a/kennel2/static/js/root.js
+++ b/kennel2/static/js/root.js
@@ -182,6 +182,12 @@ $(function() {
     }
   }
 
+  // expand window if using permlink
+  if (USING_PERMLINK) {
+    editor.expand(true).change();
+    result_container.expand(true).change();
+  }
+
   // deserialize if code exists.
   var code = JSON_CODE;
   if (code != null) {
@@ -533,6 +539,24 @@ Editor.prototype._initialize = function() {
       self.editor_changed();
   });
 
+  $(this.settings_id).find('input.expand-editor').change(function(e) {
+    var editor = $('.wandbox-smart-editor');
+    if ($(e.target).prop('checked')) {
+      editor.addClass('wandbox-expand');
+    } else {
+      editor.removeClass('wandbox-expand');
+    }
+
+    // send refresh signal to update scrollbar state
+    var code_mirror = editor.data('editor');
+    if (code_mirror) {
+      code_mirror.refresh();
+    }
+
+    if (self.editor_changed)
+      self.editor_changed();
+  });
+
   $(this.settings_id).find('input.smart-indent').change(function(e) {
     var smartIndent = $(e.target).prop('checked');
     self.contents().each(function(i) {
@@ -697,12 +721,19 @@ Editor.prototype.setLanguage = function(lang) {
   });
 }
 
+Editor.prototype.expand = function(value) {
+  var eexpand = $(this.settings_id).find('input.expand-editor');
+  eexpand.prop('checked', value);
+  return eexpand;
+}
+
 Editor.prototype.serialize = function() {
   return {
     keybinding: $(this.settings_id).find('select.wandbox-select').val(),
     spaces_or_tab: $(this.settings_id).find('select.wandbox-spaces-or-tab').val(),
     tab_width: $(this.settings_id).find('select.wandbox-tab-width').val(),
     smart_indent: $(this.settings_id).find('input.smart-indent').prop('checked'),
+    expand_editor: $(this.settings_id).find('input.expand-editor').prop('checked'),
   };
 }
 
@@ -719,10 +750,13 @@ Editor.prototype.deserialize = function(settings) {
   var esmart = $(this.settings_id).find('input.smart-indent');
   esmart.prop('checked', settings.smart_indent);
 
+  var eexpand = this.expand(settings.expand_editor);
+
   ekey.change();
   esot.change();
   etabw.change();
   esmart.change();
+  eexpand.change();
 }
 
 /* result_container */
@@ -738,6 +772,12 @@ function ResultContainer(id, settings_id) {
   $(this.settings_id).find('input.nowrap-output-window').change(function(e) {
     var content = $(self.id + ' > .tab-content');
     $(e.target).prop('checked') ? content.addClass('nowrap') : content.removeClass('nowrap')
+    if (self.result_changed)
+        self.result_changed();
+  });
+  $(this.settings_id).find('input.expand-output-window').change(function(e) {
+    var content = $(self.id + ' > .tab-content');
+    $(e.target).prop('checked') ? content.addClass('expand') : content.removeClass('expand')
     if (self.result_changed)
         self.result_changed();
   });
@@ -803,9 +843,16 @@ ResultContainer.prototype.set_code = function(compiler, code, codes, stdin, outp
   result_window.set_code(compiler, code, codes, stdin, outputs);
 }
 
+ResultContainer.prototype.expand = function(value) {
+  var eexpand = $(this.settings_id).find('input.expand-output-window');
+  eexpand.prop('checked', value);
+  return eexpand;
+}
+
 ResultContainer.prototype.serialize = function() {
   return {
     nowrap: $(this.settings_id).find('input.nowrap-output-window').prop('checked'),
+    expand: $(this.settings_id).find('input.expand-output-window').prop('checked'),
   };
 }
 
@@ -813,7 +860,10 @@ ResultContainer.prototype.deserialize = function(settings) {
   var enowrap = $(this.settings_id).find('input.nowrap-output-window');
   enowrap.prop('checked', settings.nowrap);
 
+  var eexpand = this.expand(settings.expand);
+
   enowrap.change();
+  eexpand.change();
 }
 
 /* result_window() */


### PR DESCRIPTION
I am doing this on behalf of @matkatmusic, because that user claimed to
not have a way or knowledge of how to revert a commit via PR.

This reverts commit 0396f67649a6f1e9be4f0939a0f40a4ad50dcd80.

Fixes https://github.com/melpon/wandbox/issues/256