### PR TITLE
allow Cmd+Enter to compile the code for macOS

### DIFF
--- a/kennel2/static/js/root.js
+++ b/kennel2/static/js/root.js
@@ -295,6 +295,7 @@ function Compiler(compiler_id, compile_options_id, ctrl_enter) {
          smartIndent: false,
          extraKeys: {
            'Ctrl-Enter': ctrl_enter,
+           'Cmd-Enter': ctrl_enter,
          },
        });
        $(e).data('editor', editor);
@@ -453,6 +454,10 @@ Editor.prototype._to_editor = function(elem) {
     smartIndent: false,
     extraKeys: {
       'Ctrl-Enter': function() {
+        if (self.onrun)
+          self.onrun();
+      },
+      'Cmd-Enter': function() {
         if (self.onrun)
           self.onrun();
       },
@@ -1127,6 +1132,7 @@ function Stdin(stdin_id, ctrl_enter) {
          smartIndent: false,
          extraKeys: {
            'Ctrl-Enter': ctrl_enter,
+           'Cmd-Enter': ctrl_enter,
          },
        });
        $(e).data('editor', editor);


### PR DESCRIPTION
I use macOS and it sometimes uses Cmd-X for Windows' (or Linux's) Ctrl-X, so this PR allows Cmd-Enter to compile the code as well as Ctrl-Enter.

I think it does not affect Windows nor Linux users.

BTW I'm afraid I have not checked this patch because it seems difficult for wandbox to work on macOS.