### PR TITLE
Add JS polyfill library for IE/Edge to support TextDecoder

### DIFF
--- a/kennel2/src/root.tmpl
+++ b/kennel2/src/root.tmpl
@@ -24,6 +24,7 @@
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/fast-text-encoding@1.0.0/text.min.js"></script>
 <script src="//platform.twitter.com/widgets.js" async></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.24.2/codemirror.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.24.2/addon/mode/simple.min.js"></script>


### PR DESCRIPTION
Refs #285

Sorry in Japanese:

このポリフィルライブラリを読み込むことで、TextDecoder が動作することは確認しました。
具体的には、このライブラリと、 #285 該当箇所の Base64 decode + JSON decode が動作していることは確認しました。
ただし、関連部分の JavaScript だけ抜き出して行いましたので、実際の Wandbox プログラムが全体として正しく動作するかどうかは確認していません。
IE/Edge にとって、状態が悪化するということはきっとないと思います。