### PR TITLE
Update Boost artifact URL to archives.boost.io

### DIFF
--- a/buildbase.py
+++ b/buildbase.py
@@ -691,7 +691,7 @@ def build_and_install_boost(
 ):
     version_underscore = version.replace(".", "_")
     archive = download(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version_underscore}.tar.gz",
+        f"https://archives.boost.io/release/{version}/source/boost_{version_underscore}.tar.gz",
         source_dir,
     )
     extract(archive, output_dir=build_dir, output_dirname="boost")


### PR DESCRIPTION
This pull request updates Boost artifact URL(s) from `boostorg.jfrog.io/artifactory/main/release` to `archives.boost.io/release`.

Boost have changed to a new download provider, and the old JFrog URLs are no longer available: https://github.com/boostorg/boost/issues/996